### PR TITLE
New version with Concurrent Execution

### DIFF
--- a/wav_sound.h
+++ b/wav_sound.h
@@ -97,6 +97,12 @@ private:
     unsigned long seekToData;
 
     void fillVector(vector<float> &amplTime);
+    void* fillVectorConcurr (char *buff,
+                             vector<float> &amplTime,
+                             unsigned long nBlocks,
+                             unsigned long blockAlign,
+                             unsigned short depth,
+                             unsigned long index);
     float strtoampl(const char* str, const unsigned short depth);
 };
 


### PR DESCRIPTION
Now amplitudes are got concurrently, threads used.
When vector is given in fillVector, it is cleared and properly resized
in advance.
