### PR TITLE
Added correct handling of lack of memory.

### DIFF
--- a/wav_sound.h
+++ b/wav_sound.h
@@ -20,7 +20,7 @@
 
 using namespace std;
 
-const long SIZE_OF_CHUNKID = 4;
+const unsigned long SIZE_OF_CHUNKID = 4;
 
 struct RiffWaveHeader
 {
@@ -97,6 +97,7 @@ private:
     unsigned long seekToData;
 
     void fillVector(vector<float> &amplTime);
+    void fillVectorBySegments (vector<float> &amplTime);
     void* fillVectorConcurr (char *buff,
                              vector<float> &amplTime,
                              unsigned long nBlocks,


### PR DESCRIPTION
Now if new in fillVector failed, the fillVectorBySegments is called. It
divides file into segments and allocates memory for them in series.
Algorithm tries to make as less segments a possible.
Several mistakes fixed.
